### PR TITLE
Add version and MathJax configurability

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
 	  linebreaks: { automatic: true, width: "container" }          
 	}              
 	}); */
-	window.MathJax = {
+	
+var	config = {
   tex: {
     inlineMath: [["$","$"],["\\(","\\)"]],
     autoload: {
@@ -31,6 +32,22 @@
     load: ['[tex]/noerrors']
   }
 };
+window.MathJax = JSON.parse(JSON.stringify(config));
+
+let path =  new URL(document.URL)
+	let input = path.searchParams.get("c");
+	if(input !== null){
+
+window.MathJax = JSON.parse(input);
+config = JSON.parse(input);
+
+	}
+	else if(sessionStorage.getItem("configgy") !== null){
+		
+window.MathJax = JSON.parse(sessionStorage.getItem("configgy"));
+config = JSON.parse(sessionStorage.getItem("configgy"));
+	}
+
 	</script>
 	<script
   src="https://code.jquery.com/jquery-3.7.1.min.js"
@@ -38,14 +55,13 @@
   crossorigin="anonymous"></script>
 <!-- 	<script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script> -->
 	<!-- Latest compiled and minified CSS --> 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/css/bootstrap.min.css" integrity="sha256-PI8n5gCcz9cQqQXm3PEtDuPG8qx9oFsFctPg0S5zb8g=" crossorigin="anonymous">
 	<!-- Latest compiled and minified JavaScript -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/js/bootstrap.min.js" integrity="sha256-3gQJhtmj7YnV1fmtbVcnAV6eI4ws0Tr48bVZCThtCGQ=" crossorigin="anonymous"></script>
 	
 	<!-- Polyfill for URL-->
-	<script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/mathjax@4.0.0-beta.4/tex-mml-chtml.js" id="MathJax-script"></script>
+	<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/mathjax@4.0.0-beta.7/tex-mml-chtml.js" id="MathJax-script"></script>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>.btn{margin-top: 7px; display:inline-block;}#inputty, #putty{min-height: 50px;}</style>
@@ -54,6 +70,8 @@
 	<div class="container">
 		<div class="page-header">
 			<h1>MathJax Viewer <small>Edit &amp; preview</small></h1>
+			<img alt="GitHub Tag" src="https://img.shields.io/github/v/tag/saxarona/mathjax-viewer?label=release">
+
 		</div>
 		<p>Type in an equation in \(LaTeX\) format. If your syntax is correct, it should show up accordingly on the right. Copy the URL to share.</p>
 		<br>
@@ -73,6 +91,10 @@
 				<li>No need to add <code>\(</code> or <code>\)</code> at the start or end of your equation.</li>
 				<li>Use <code>\left(</code> and <code>\right)</code> to resize parenthesis around a fraction.</li>
 				</ul>
+				<div id="scooby" class="col-6 col-md-6" >
+					<label>MathJax Configuration</label>
+					<textarea id="configgy" class="form-control" placeholder="Config"  rows="1" cols="1" style="height: 30em;"></textarea>
+			 </div>
 			</div>
 			<div class="col-6 col-md-6">
 				<h3>Useful Links</h3>
@@ -98,7 +120,9 @@
 					const urlParams = new URLSearchParams(window.location.search);
 
 					urlParams.set('input',$("#inputty").val() );
-
+					if (sessionStorage.getItem("configgy") !== null) {
+  urlParams.set('c',sessionStorage.getItem("configgy"))
+}
 					history.replaceState(null, null, '?' + urlParams.toString());
 
 				}
@@ -108,10 +132,17 @@
 				$('#inputty').on('input', function() {
     setLocation();
 });
+$('#configgy').on("blur", function() {
+	sessionStorage.setItem("configgy",$("#configgy").val())
+	window.location.reload();
+   
+});
 					window.onload = function() {
 				let path =  new URL(document.URL)
 				let input = path.searchParams.get("input");
 				$("#inputty").val(input);
+				//$("#configgy").attr('placeholder',config);
+				$('#configgy').val(JSON.stringify(config));
 				doIt();
 			};
 				


### PR DESCRIPTION
A version badge is added to the site and would close #4. Viewers can now modify the MathJax configuration to add packages such as physics etc.

If merged, check if badge shows version, and if not create a tag named "4.0.0-beta.7". Changes can be found at https://programcomputer.github.io/mathjax-viewer, but release tag refers to this repository.

Polyfill changed to Cloudflare.